### PR TITLE
Update GitHub workflow and disable unified namespace

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   build:
+    permissions:
+      id-token: write
+
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/goldenm-software/python-builder:3.11
@@ -25,7 +28,7 @@ jobs:
           python3 -m build
         
       - name: Upload to Python Package Index
-        uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
+        uses: pypa/gh-action-pypi-publish@v1.8.10
         with:
           user: ${{ secrets.LAYRZ_PYPI_USERNAME }}
           password: ${{ secrets.LAYRZ_PYPI_PASSWORD }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "telegram-sdk"
-version = "1.1.0"
+version = "1.1.1"
 description = "Telegram SDK for public or private Telegram API"
 authors = [
   {name = "Golden M, Inc.", email = "software@goldenm.com"}
@@ -28,11 +28,6 @@ classifiers = [
 dependencies = [
   "requests",
 ]
-
-[tool.setuptools.packages.find]
-where = ["."]
-include = ["telegram.*"]
-namespaces = true
 
 [build-system]
 requires = ["setuptools", "setuptools-scm"]

--- a/telegram/__init__.py
+++ b/telegram/__init__.py
@@ -1,9 +1,1 @@
-""" Telegram unified namespace """
-try:
-  import pkg_resources
-
-  pkg_resources.declare_namespace(__name__)
-except ImportError:
-  import pkgutil
-
-  __path__ = pkgutil.extend_path(__path__, __name__)  # type: ignore
+""" Telegram SDK namespace """


### PR DESCRIPTION
This pull request updates the GitHub workflow and disables the unified namespace in pyproject.toml. The GitHub workflow now includes write permissions and uses the latest version of the pypa/gh-action-pypi-publish action. The unified namespace in pyproject.toml has been disabled.

No issue number is associated with this pull request.