### PR TITLE
Remove unnecessary permissions from deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,9 +7,6 @@ on:
 
 jobs:
   build:
-    permissions:
-      id-token: write
-
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/goldenm-software/python-builder:3.11


### PR DESCRIPTION
This pull request removes the "id-token: write" permission from the deploy.yml file, as it is unnecessary and potentially insecure. This change ensures that the deployment process is more secure and streamlined.

No issue reference needed.